### PR TITLE
a fix for refTangentError type

### DIFF
--- a/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.C
+++ b/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.C
@@ -734,14 +734,15 @@ coupledTotalLagNewtonRaphsonBeam::coupledTotalLagNewtonRaphsonBeam
     R0 = mesh().C();
     const vectorField refTangentError(fvc::snGrad(R0) - vector(1, 0, 0));
     
-    if (sum(mag(refTangentError)) > 1e-06 )
+    if (max(mag(refTangentError)) > 1e-06)
     {
         FatalErrorIn
         (
             "Constructor of Foam::coupledTotalLagNewtonRaphsonBeam "
         )   << "The longitudinal axis of beam in the reference configuration " << nl
             << "is not aligned the global x-axis : This is a mandatory " << nl
-            << "requirement before running the beam solver. Run the " << nl
+            << "requirement before running the beam solver. For example, " << nl
+            << "if the current beam is oriented in the Z direction, run the "
             << "following command: " << nl
             << "    transformPoints -rotate-angle '((0 1 0) 90)'" << nl
             << "after creating the beam mesh to set the correct reference "


### PR DESCRIPTION
Hi @Seevanibali @philipcardiff 

When I was about to update the `moorFV` repository based on recent changes of `solids4foam/beamFoam`, I faced an Error upon executing `beamFoam`; eventually, I found out that it was due to the calculation of surface normal vectors of cell centers for `refTangentError.`

 FYI, if you look at `$FOAM_SRC/finiteVolume/fvMesh/fvMeshGeometry.C`, you see that `mesh.C()`, creates a `slicedVolVectorField` which has `internalField` and `boundaryField`, 

Also, if you look at `$FOAM_SRC/finiteVolume/fields/fvPatchFields/basic/sliced/slicedFvPatchField.C` , you'll see that for `slicedVolVectorField`, there is no `snGrad()` defined (also `grad()`).

```
template<class Type>
    Foam::tmp<Foam::Field<Type>> Foam::slicedFvPatchField<Type>::snGrad() const
    {
        NotImplemented;
        return Field<Type>::null();
    }

```
To solve this, I created a plain field for `R0` and made a copy of the `mesh().C()`; see (https://github.com/solids4foam/beamFoam/commit/0e3b1b9d2abf9389c603058b43b4ea919e42e6da) .


**Besides**, @Seevanibali, I am still getting `fatalError` even though I have been transforming using `transformPoints -rotate-angle '((0 1 0) 90)'` in my case.

For now, in (https://github.com/solids4foam/beamFoam/commit/0e3b1b9d2abf9389c603058b43b4ea919e42e6da), I have commented out the `fatalError` section, but I think it would be better if you could take a look at this.


