### PR TITLE
Corrections to use the correct width when using rectangular cross sections

### DIFF
--- a/src/wireBunchingModels/beamModels/beamModel/crossSections/crossSection/crossSectionModel.H
+++ b/src/wireBunchingModels/beamModels/beamModel/crossSections/crossSection/crossSectionModel.H
@@ -156,6 +156,15 @@ public:
     
         //- Return cross-section area
         virtual scalar A() const = 0;
+
+        // remi - Return width
+        virtual scalar h() const
+        {
+            FatalErrorInFunction
+                << "h() not implemented for base class crossSectionModel"
+                << exit(FatalError);
+            return 0;
+        }
     
         //- Return cross-section moment of inertia
         virtual scalar Ixx() const = 0;

--- a/src/wireBunchingModels/beamModels/beamModel/crossSections/rectangle/rectangle.C
+++ b/src/wireBunchingModels/beamModels/beamModel/crossSections/rectangle/rectangle.C
@@ -143,6 +143,7 @@ tmp<vectorField> rectangle::greenLagrangianStrain
     avgE[4] = K.y();
     avgE[5] = K.z();
 
+
     scalarRectangularMatrix A(3, 6, 0);
 
     forAll(points_, pI)
@@ -160,7 +161,6 @@ tmp<vectorField> rectangle::greenLagrangianStrain
 
     return tE;
 }
-
 
 tmp<scalarField> rectangle::resultantTotalForce(const vectorField& S) const
 {
@@ -191,7 +191,13 @@ tmp<scalarField> rectangle::resultantTotalForce(const vectorField& S) const
     
     return trF;
 }
-    
+
+// remi
+scalar rectangle::h() const
+{
+    return h_;
+}
+
 vector rectangle::resultantForce(const vectorField& S) const
 {
     vector rF = vector::zero;
@@ -203,7 +209,6 @@ vector rectangle::resultantForce(const vectorField& S) const
     
     return rF;
 }
-
 
 void rectangle::resultantTangentMatrices
 (
@@ -229,6 +234,7 @@ void rectangle::resultantTangentMatrices
     // scalarRectangularMatrix ACA(6, 6, 0);
 
     scalarRectangularMatrix DSDE(6, 6, 0);
+
 
     for (label fI=0; fI<quadFaces_.size(); fI++)
     {
@@ -369,7 +375,6 @@ void rectangle::resultantTangentMatrices
     DMDK.zz() = DSDE[5][5];
 }
 
-
 vector rectangle::resultantMoment(const vectorField& S) const
 {
     vector rM = vector::zero;
@@ -394,7 +399,6 @@ vector rectangle::resultantMoment(const vectorField& S) const
     return rM;
 }
 
-
 void rectangle::writeVTK
 (
     const fileName& fn,
@@ -411,7 +415,6 @@ void rectangle::writeVTK
     vtkFile << "ASCII" << endl;
     vtkFile << "DATASET POLYDATA" << endl;
     // vtkFile << "DATASET UNSTRUCTURED_GRID" << endl;
-
 
     // Write points
     vtkFile << "\nPOINTS " << points_.size() << " float" << endl;

--- a/src/wireBunchingModels/beamModels/beamModel/crossSections/rectangle/rectangle.H
+++ b/src/wireBunchingModels/beamModels/beamModel/crossSections/rectangle/rectangle.H
@@ -127,11 +127,11 @@ public:
             return h_/2;
         }
     
-        //- Return the width b
-        virtual scalar b() const
-        {
-            return b_;
-        }
+        //- Return the width h, remi
+        virtual scalar h() const;
+        //{
+        //    return b_;
+        //}
 
         //- Return cross-section area
         virtual scalar A() const

--- a/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.C
+++ b/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.C
@@ -1067,7 +1067,8 @@ scalar coupledTotalLagNewtonRaphsonBeam::evolve()
             // y-dir
             // const scalar width = crossSections()[0].widthY();
             // Check if the radius at 0 degrees is consistent with widthY
-            const scalar width = crossSections()[0].radius(0);
+            //const scalar width = crossSections()[0].radius(0);
+            const scalar width = crossSections()[0].h();
             const scalar A = crossSections()[0].A();
 
             // Update the force


### PR DESCRIPTION
PR with the correct branches:

Made a few changes to use the correct width for the calculations. It compiles and works for the rectangular cross-section, I haven't checked if it still works for circular cross-sections after making the changes.

Not sure whether it's coded properly, as I don't really know C/C++, but Niels recommended that I push anyway, as long as it works.