### PR TITLE
Adding `functionObjects` to the main repo

### DIFF
--- a/src/wireBunchingModels/functionObjects/beamConvergenceData/Make/files
+++ b/src/wireBunchingModels/functionObjects/beamConvergenceData/Make/files
@@ -1,3 +1,0 @@
-beamConvergenceData.C
-
-LIB = $(FOAM_USER_LIBBIN)/libbeamConvergenceDataFunctionObject

--- a/src/wireBunchingModels/functionObjects/beamConvergenceData/Make/options
+++ b/src/wireBunchingModels/functionObjects/beamConvergenceData/Make/options
@@ -1,7 +1,0 @@
-EXE_INC = \
-    -I$(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/meshTools/lnInclude
-
-LIB_LIBS = \
-    -lfiniteVolume \
-    -lmeshTools

--- a/src/wireBunchingModels/functionObjects/beamDisplacements/Make/files
+++ b/src/wireBunchingModels/functionObjects/beamDisplacements/Make/files
@@ -1,3 +1,0 @@
-beamDisplacements.C
-
-LIB = $(FOAM_USER_LIBBIN)/libbeamDisplacementsFunctionObject

--- a/src/wireBunchingModels/functionObjects/beamDisplacements/Make/options
+++ b/src/wireBunchingModels/functionObjects/beamDisplacements/Make/options
@@ -1,7 +1,0 @@
-EXE_INC = \
-    -I$(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/meshTools/lnInclude
-
-LIB_LIBS = \
-    -lfiniteVolume \
-    -lmeshTools

--- a/src/wireBunchingModels/functionObjects/beamDisplacements/beamDisplacements.C
+++ b/src/wireBunchingModels/functionObjects/beamDisplacements/beamDisplacements.C
@@ -71,7 +71,8 @@ bool Foam::functionObjects::beamDisplacements::writeData()
                 << mesh.time().value() << " "
                 << avgW.x() << " "
                 << avgW.y() << " "
-                << avgW.z()
+                << avgW.z() << " "
+                << mag(avgW)
                 << endl;
             }
         }
@@ -176,7 +177,8 @@ Foam::functionObjects::beamDisplacements::beamDisplacements
                     << "Time" << " "
                     << "w_x" << " "
                     << "w_y" << " "
-                    << "w_z"
+                    << "w_z" << " "
+                    << "mag(w)"
                     << endl;
             }
         }

--- a/src/wireBunchingModels/functionObjects/beamEnergyData/Make/files
+++ b/src/wireBunchingModels/functionObjects/beamEnergyData/Make/files
@@ -1,3 +1,0 @@
-beamEnergyData.C
-
-LIB = $(FOAM_USER_LIBBIN)/libbeamEnergyDataFunctionObject

--- a/src/wireBunchingModels/functionObjects/beamEnergyData/Make/options
+++ b/src/wireBunchingModels/functionObjects/beamEnergyData/Make/options
@@ -1,7 +1,0 @@
-EXE_INC = \
-    -I$(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/meshTools/lnInclude
-
-LIB_LIBS = \
-    -lfiniteVolume \
-    -lmeshTools

--- a/src/wireBunchingModels/functionObjects/beamForcesMoments/Make/files
+++ b/src/wireBunchingModels/functionObjects/beamForcesMoments/Make/files
@@ -1,3 +1,0 @@
-beamForcesMoments.C
-
-LIB = $(FOAM_USER_LIBBIN)/libbeamForcesMomentsFunctionObject

--- a/src/wireBunchingModels/functionObjects/beamForcesMoments/Make/options
+++ b/src/wireBunchingModels/functionObjects/beamForcesMoments/Make/options
@@ -1,7 +1,0 @@
-EXE_INC = \
-    -I$(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/meshTools/lnInclude
-
-LIB_LIBS = \
-    -lfiniteVolume \
-    -lmeshTools


### PR DESCRIPTION
Adding the following `functionObjects` for post-processing the data to the main repo.

The list of `functionObjects` includes:
1. `beamDisplacements` - Extracts x, y, z displacement components on a beam patch
2. `beamForcesMoments` - Extracts x, y, z force and moment components on a beam patch
3. `beamConvergenceData` - Extracts the number of Newton-Raphson correctors per time step
4. `beamEnergyData` - Calculates and reports the internal, kinetic and total energy of the beam - ideal for dynamic simulations.

@philipcardiff, @cloner0110, please feel free to suggest any other `functionObjects` you think would be relevant.