### PR TITLE
Refactoring the CTLNRB.C/.H code and CTLNRBEvolve.C code

### DIFF
--- a/src/wireBunchingModels/beamModels/beamModel/beamModel.C
+++ b/src/wireBunchingModels/beamModels/beamModel/beamModel.C
@@ -345,7 +345,7 @@ Foam::beamModel::beamModel
 
     if (gHeader.typeHeaderOk<uniformDimensionedVectorField>(true))
     {
-        gPtr_.set
+        gPtr_.reset
         (
             new uniformDimensionedVectorField
             (
@@ -395,7 +395,7 @@ Foam::beamModel::beamModel
     }
     else
     {
-        gPtr_.set
+        gPtr_.reset
         (
             new uniformDimensionedVectorField
             (
@@ -454,7 +454,7 @@ Foam::beamModel::beamModel
         (
             nBeams,
             dimensionedScalar(this->lookup("R")).value()
-        );
+         );
         if (this->found("U"))
         {
             U_.setSize

--- a/src/wireBunchingModels/beamModels/beamModel/beamModel.C
+++ b/src/wireBunchingModels/beamModels/beamModel/beamModel.C
@@ -304,10 +304,10 @@ Foam::beamModel::beamModel
     pointForces_(),
     iOuterCorr_(0),
     steadyState_(beamProperties_.getOrDefault<bool>("steadyState", true)),
-    objectiveInterpolation_
-    (
-        beamProperties_.getOrDefault<bool>("objectiveInterpolation", false)
-    ),
+    // objectiveInterpolation_
+    // (
+    //     beamProperties_.getOrDefault<bool>("objectiveInterpolation", false)
+    // ),
     kCI_(beamProperties_.getOrDefault<scalar>("scalingInertiaTensor", 1)),
 
     startToRelaxTime_

--- a/src/wireBunchingModels/beamModels/beamModel/beamModel.H
+++ b/src/wireBunchingModels/beamModels/beamModel/beamModel.H
@@ -29,6 +29,7 @@ Description
 
 Author
     Zeljko Tukovic, FSB Zagreb.  All rights reserved.
+    Seevani Bali, UCD.
 
 SourceFiles
     beamModel.C
@@ -180,8 +181,11 @@ class beamModel
         //- Steady state calculation
         bool steadyState_;
 
-        //- Use objective interpolation for rotation
-        bool objectiveInterpolation_;
+        // //- Use objective interpolation for rotation
+        // bool objectiveInterpolation_;
+
+        //- Artificial scaling factor for changing the inertia
+        //- tensor I_rho in the angular momentum tensor 
         scalar kCI_;
 
         //- Conical pullys
@@ -794,16 +798,18 @@ public:
                 return steadyState_;
             }
 
-            //- Steady state
-            bool objectiveInterpolation() const
+            // //- Objective interpolation
+            // bool objectiveInterpolation() const
+            // {
+            //     return objectiveInterpolation_;
+            // }
+
+            //- Artificial scaling factor for changing the inertia
+            //- tensor I_rho in the angular momentum tensor 
+            scalar kCI() const
             {
-                return objectiveInterpolation_;
+                return kCI_;
             }
-            //- Rotation inertia tensor scaling
- 	          scalar kCI() const
- 	          {
- 		            return kCI_;
- 	          }
 
             //- Get upper neighbour cell faces
             const labelList& upperNeiCellFaces() const;

--- a/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.C
+++ b/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.C
@@ -739,11 +739,18 @@ coupledTotalLagNewtonRaphsonBeam::coupledTotalLagNewtonRaphsonBeam
             "Constructor of Foam::coupledTotalLagNewtonRaphsonBeam "
         )   << "The longitudinal axis of beam in the reference configuration " << nl
             << "is not aligned the global x-axis : This is a mandatory " << nl
-            << "requirement before running the beam solver. For example, " << nl
+            << "requirement before running the beam solver. Check the beam mesh " << nl
+            << "in paraview. For example, " << nl
             << "if the current beam is oriented in the Z direction, run the "
             << "following command: " << nl
             << "    transformPoints -rotate-angle '((0 1 0) 90)'" << nl
-            << "after creating the beam mesh to set the correct reference "
+            << "after creating the beam mesh to set the correct reference " << nl
+            << nl
+            << "You might also be using a deprecated mesh utility " << nl
+            << " 'createCircularBeamMesh' or 'createMultipleBeamMesh' "
+            << " along with transformPoints command! " << nl << nl
+            << " Use 'createBeamMesh' utility instead! and remove  "
+            << " transformPoints command! " << nl
             << abort(FatalError);
     }
 

--- a/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.H
+++ b/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.H
@@ -257,8 +257,8 @@ class coupledTotalLagNewtonRaphsonBeam
         /*-----------------------------------------------*/
 
         //- Update the coefficients associated with the primary
-        //- variables W_ and Theta_ 
-        //- Function call implemented in 
+        //- variables W_ and Theta_
+        //- Function call implemented in
         //- 'coupledTotalLagNewtonRaphsonBeamEvolve.C'
         void updateEqnCoefficients();
 

--- a/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.H
+++ b/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeam.H
@@ -202,22 +202,32 @@ class coupledTotalLagNewtonRaphsonBeam
         surfaceTensorField CDQDK_;
 
         //- Beam momentum inertial term constant
- 	    dimensionedScalar ARho_;
+        dimensionedScalar ARho_;
 
         //- Beam cross-section constant
- 	    dimensionedTensor CIRho_;
+        dimensionedTensor CIRho_;
 
-    // Fields related to Newmark-beta time integration scheme
+    //- Fields related to time integration schemes
+
+        //- ddtScheme name from fvSchemes dictionary
+        //- Used to check whether steadyState or not
+        const word ddtSchemeName_;
+
+        //- d2dt2Scheme name from fvSchemes dictionary
+        const word d2dt2SchemeName_;
+
+    //- Fields related to Newmark-beta time integration scheme
 
         //- Boolean to activate Newmark-beta time-integration scheme
-        bool newmark_;
+        // bool newmark_;
 
         //- Newmark beta coefficient
         scalar betaN_;
 
         //- Newmark gamma coefficient
         scalar gammaN_;
-        //- Fields related to drag forces due to Morrison's equation
+
+    //- Fields related to drag forces due to Morrison's equation
         //- Boolean to activate drag forces
         bool dragActive_;
 
@@ -331,7 +341,6 @@ public:
         {}
 
     // Member Functions
-
         // Access
             //- Each beamModel must indicate whether W or DW is the primary
             //  solution variable

--- a/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeamEvolve.C
+++ b/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeamEvolve.C
@@ -662,35 +662,35 @@ scalar coupledTotalLagNewtonRaphsonBeam::evolve()
             }
 
 
-            if (objectiveInterpolation())
-            {
-                // Info<< "Using objective interpolation for rotation" << endl;
+            // if (objectiveInterpolation())
+            // {
+            //     // Info<< "Using objective interpolation for rotation" << endl;
 
-                // Calculate rotation matrix correction from
-                // cell-centre rotation vector correction
-                volTensorField DLambda(rotationMatrix(DTheta_));
+            //     // Calculate rotation matrix correction from
+            //     // cell-centre rotation vector correction
+            //     volTensorField DLambda(rotationMatrix(DTheta_));
 
-                // Update cell-centre rotation matrix
-                Lambda_ = (DLambda & Lambda_);
+            //     // Update cell-centre rotation matrix
+            //     Lambda_ = (DLambda & Lambda_);
 
-                // Calculate mean line curvature at cell-faces
-                K_ = refLambdaf_.T() & meanLineCurvature(Lambda_); // this does not work
-                //K_ +=
-                //    (
-                //          (refLambdaf_.T() & Lambdaf_.T()) &
-                //        meanLineCurvature(DLambda)
-                //    );
+            //     // Calculate mean line curvature at cell-faces
+            //     K_ = refLambdaf_.T() & meanLineCurvature(Lambda_); // this does not work
+            //     //K_ +=
+            //     //    (
+            //     //          (refLambdaf_.T() & Lambdaf_.T()) &
+            //     //        meanLineCurvature(DLambda)
+            //     //    );
 
-                // Objective cell-to-face interpolation of rotation matrix correction
-                //surfaceTensorField DLambdaf =
-                //   interpolateRotationMatrix(DLambda);
+            //     // Objective cell-to-face interpolation of rotation matrix correction
+            //     //surfaceTensorField DLambdaf =
+            //     //   interpolateRotationMatrix(DLambda);
 
-                // Update cell-face rotation matrix
-                //Lambdaf_ = (DLambdaf & Lambdaf_);
-                Lambdaf_ = interpolateRotationMatrix(Lambda_); // this does not work
-            }
-            else
-            {
+            //     // Update cell-face rotation matrix
+            //     //Lambdaf_ = (DLambdaf & Lambdaf_);
+            //     Lambdaf_ = interpolateRotationMatrix(Lambda_); // this does not work
+            // }
+            // else
+            // {
                 //Info<< "Rotations are not interpolated objectively \n" << endl;
                 const surfaceVectorField DThetaf(fvc::interpolate(DTheta_));
 
@@ -751,7 +751,7 @@ scalar coupledTotalLagNewtonRaphsonBeam::evolve()
                 {
                     Omega_ = axialVector(Lambda_.T() & fvc::ddt(Lambda_));
                 }
-            }
+            // }
 
             // Update axial and shear strain vector
             {

--- a/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeamEvolve.C
+++ b/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeamEvolve.C
@@ -292,23 +292,23 @@ scalar coupledTotalLagNewtonRaphsonBeam::evolve()
             // Add body force due to gravity and buoyancy if fluid is present
             // Note that for buoyant force calculation it is assumed
             // that the entire beam is submerged in the fluid
-            forAll(source, cellI)
-            {
-                source[cellI](0,0) -=
-                    (
-                        rho().value() - rhoFluid().value()
-                    )*L()[cellI]*A().value()*g().component(0).value();
+            // forAll(source, cellI)
+            // {
+            //     source[cellI](0,0) -=
+            //         (
+            //             rho().value() - rhoFluid().value()
+            //         )*L()[cellI]*A().value()*g().component(0).value();
 
-                source[cellI](1,0) -=
-                    (
-                        rho().value() - rhoFluid().value()
-                    )*L()[cellI]*A().value()*g().component(1).value();
+            //     source[cellI](1,0) -=
+            //         (
+            //             rho().value() - rhoFluid().value()
+            //         )*L()[cellI]*A().value()*g().component(1).value();
 
-                source[cellI](2,0) -=
-                    (
-                        rho().value() - rhoFluid().value()
-                    )*L()[cellI]*A().value()*g().component(2).value();
-            }
+            //     source[cellI](2,0) -=
+            //         (
+            //             rho().value() - rhoFluid().value()
+            //         )*L()[cellI]*A().value()*g().component(2).value();
+            // }
 
             // ground contact contribution
             if (groundContactActive_)
@@ -538,7 +538,7 @@ scalar coupledTotalLagNewtonRaphsonBeam::evolve()
                 }
             }
 
-            // Throw warning if drag active flag is true but the time scheme is
+            // Throw error if drag active flag is true but the time scheme is
             // steady state because the drag forces will be zero.
             if
             (
@@ -549,13 +549,15 @@ scalar coupledTotalLagNewtonRaphsonBeam::evolve()
                 )
             )
             {
-                WarningIn("coupledTotalLagNewtonRaphsonBeam::evolve()")
+                FatalErrorInFunction
                   << "Drag forces are zero for steady state calculation"
                   << nl
                   << "Set d2dt2Scheme type in system/fvSchemes as "
-                  << "'Euler' or 'Newmark' & 'dragActive' flag "
-                  << "in constant/beamProperties to true "
-                  << "to include drag force contributions" << nl << endl;
+                  << "'Euler' or 'Newmark' & 'dragActive' flag to 'true' "
+                  << "inside coupledTotalLagNewtownRaphsonCoeffs "
+                  << "sub-dictionary of constant/beamProperties "
+                  << "to include drag force contributions"
+                  << abort(FatalError);
             }
 
             // Calculate equilibrium equations residual

--- a/tutorials/ofw-paper/myCantilever_followerEndForce/system/fvSchemes
+++ b/tutorials/ofw-paper/myCantilever_followerEndForce/system/fvSchemes
@@ -19,6 +19,11 @@ ddtSchemes
     default         steadyState;
 }
 
+d2dt2Schemes
+{
+    default         steadyState;
+}
+
 gradSchemes
 {
   default        none;


### PR DESCRIPTION
Hi @philipcardiff, @cloner0110,

This PR contains three commits: one major and two minor.

Minor changes:
Commented out objectiveInterpolation keyword and section in the `CTLNRB.C`  and `beamModel.C` - 33e3e992d6d314485f54b4e07bad63442893d903 
and e84b89558e4f391eff2a5f16e87a0eaab16ccb53

Major refactoring changes:
5cdb1f04dbb46c9d50e92dc7a2a94e1cccb55d1a
1. Added keywords ddtSchemeName_ and d2dt2SchemeName_ to read the time integration schemes from system/fvSchemes
<img width="1228" height="722" alt="image" src="https://github.com/user-attachments/assets/7dee57a4-72e7-40ed-9179-c0d3e64c832d" />

2. Added a check to make the ddt and d2dt2 Schemes consistent and to throw fatal errors if the d2dt2Scheme is not provided or if the provided ddtScheme and d2dt2Scheme are not consistent. 
<img width="1212" height="232" alt="image" src="https://github.com/user-attachments/assets/3a60729c-543a-4386-bc61-bfcac616085b" />

<img width="1214" height="408" alt="image" src="https://github.com/user-attachments/assets/8c8306db-31bd-4e7d-b561-5f97a6abf52e" />


4. Refactored the inertia contributions of the code
- In `coupledTotalLagNewtonRaphsonBeamEvolve.C`, removed the repetitive loops to add the explicit contributions of the inertia force and moment terms for Newmark and Euler, as the explicit contribution is essentially the same code.

<img width="1048" height="1160" alt="image" src="https://github.com/user-attachments/assets/eeb8fd49-12ac-46b4-884f-c485948a427a" />

-  Added if-else statements to check which time integration scheme is specified in the test case, and accordingly added the implicit contribution to the diagonal.
<img width="1364" height="1036" alt="image" src="https://github.com/user-attachments/assets/3072f856-4d87-4e75-9013-5ad0633359db" />

<img width="1438" height="204" alt="image" src="https://github.com/user-attachments/assets/e589407a-fbf4-47d4-9797-96084f4f5db1" />

- Changed the location of dragActive_  portion of the code, which @cloner0110 had initially added only in the Euler part of the inertia loop. This dragActive_ portion is independent of Euler/Newmark. Hence, the dragActive_ loop is kept outside the if-else loop of Euler and Newmark. This idea was discussed with @cloner0110 and was agreed upon.

Philip and Amir, please let me know your comments. 

Thanks,
Seevani.

