### PR TITLE
Fix density inconsistency bug for multi-beam case

### DIFF
--- a/src/wireBunchingModels/beamModels/beamModel/beamModel.C
+++ b/src/wireBunchingModels/beamModels/beamModel/beamModel.C
@@ -365,24 +365,6 @@ Foam::beamModel::beamModel
             << g()
             << endl;
 
-        if (!beamProperties().found("rho"))
-        {
-            FatalErrorInFunction
-                << "rho field not set in beamProperties for"
-                << " calculating the gravity body force"
-                << abort(FatalError);
-        }
-        else if
-        (
-            mag(dimensionedScalar("rho", beamProperties()).value()) < SMALL
-        )
-        {
-            WarningInFunction
-                << "rho field in constant/beamProperties = "
-                << "zero --> gravitational body force = 0"
-                << nl << endl;
-        }
-
         // To check whether density of fluid is specified to calculate
         // buoyant body force
         if (beamProperties().found("rhoFluid"))
@@ -559,6 +541,25 @@ Foam::beamModel::beamModel
                 << endl;
         }
 
+    }
+
+    const bool gravityBodyForce =
+        mag(g().component(0).value()) > SMALL
+     || mag(g().component(1).value()) > SMALL
+     || mag(g().component(2).value()) > SMALL;
+
+    if (gravityBodyForce)
+    {
+        forAll(rho_, beamI)
+        {
+            if (mag(rho_[beamI]) < SMALL)
+            {
+                WarningInFunction
+                    << "rho for beam " << beamI << " = zero"
+                    << " --> gravitational body force = 0 for this beam"
+                    << nl << endl;
+            }
+        }
     }
 
     // Write beam cross-section properties

--- a/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeamEvolve.C
+++ b/src/wireBunchingModels/beamModels/coupledTotalLagNewtonRaphsonBeam/coupledTotalLagNewtonRaphsonBeamEvolve.C
@@ -200,9 +200,12 @@ scalar coupledTotalLagNewtonRaphsonBeam::evolve()
             // Add self-weight of the beam
             forAll(source, cellI)
             {
-                source[cellI](0,0) -= rho().value()*L()[cellI]*A().value()*g().component(0).value();
-                source[cellI](1,0) -= rho().value()*L()[cellI]*A().value()*g().component(1).value();
-                source[cellI](2,0) -= rho().value()*L()[cellI]*A().value()*g().component(2).value();
+                const label bI = whichBeam(globalCellIndex(cellI));
+                const scalar beamWeight = rho(bI).value()*L()[cellI]*A(bI).value();
+
+                source[cellI](0,0) -= beamWeight*g().component(0).value();
+                source[cellI](1,0) -= beamWeight*g().component(1).value();
+                source[cellI](2,0) -= beamWeight*g().component(2).value();
             }
             // Add point forces
             forAll(pointForces(), pfI)

--- a/src/wireBunchingModels/functionObjects/beamEnergyData/beamEnergyData.C
+++ b/src/wireBunchingModels/functionObjects/beamEnergyData/beamEnergyData.C
@@ -43,6 +43,42 @@ namespace functionObjects
 }
 }
 
+namespace
+{
+    static const Foam::label energyWidth = 16;
+
+    void writeEnergyHeader(Foam::OFstream& os)
+    {
+        os  << Foam::setw(energyWidth) << "Time"
+            << Foam::setw(energyWidth) << "E_{int}"
+            << Foam::setw(energyWidth) << "E_{kin}"
+            << Foam::setw(energyWidth) << "E_{kin-lin}"
+            << Foam::setw(energyWidth) << "E_{kin-ang}"
+            << Foam::setw(energyWidth) << "E_{tot}"
+            << Foam::endl;
+    }
+
+    void writeEnergyRow
+    (
+        Foam::OFstream& os,
+        const Foam::scalar time,
+        const Foam::scalar intE,
+        const Foam::scalar kinE,
+        const Foam::scalar kinE_lin,
+        const Foam::scalar kinE_ang,
+        const Foam::scalar totE
+    )
+    {
+        os  << Foam::setw(energyWidth) << time
+            << Foam::setw(energyWidth) << intE
+            << Foam::setw(energyWidth) << kinE
+            << Foam::setw(energyWidth) << kinE_lin
+            << Foam::setw(energyWidth) << kinE_ang
+            << Foam::setw(energyWidth) << totE
+            << Foam::endl;
+    }
+}
+
 // * * * * * * * * * * * Private Members Functions * * * * * * * * * * * * * //
 
 bool Foam::functionObjects::beamEnergyData::writeData()
@@ -62,23 +98,6 @@ bool Foam::functionObjects::beamEnergyData::writeData()
 
     // Properties of the beam like length, area, second moment of area, density
     const volScalarField& L = beam.L();
-    const dimensionedScalar& rho = beam.rho();
-    const dimensionedScalar& A = beam.A();
-    const dimensionedScalar& Iyy = beam.Iyy();
-    const dimensionedScalar& Izz = beam.Izz();
-    const dimensionedScalar& J = beam.J();
-
-    // Second moment of area scaling factor-if not specified in beamProperties
-    // then the value is equal to 1.0
-    const scalar kCI = beam.kCI();
-
-    // Inertia tensor
-    tensor CI
-    (
-        kCI*J.value(), 0, 0,
-        0, kCI*Iyy.value(), 0,
-        0, 0, kCI*Izz.value()
-    );
 
     // Beam linear and angular velocity for calculation of kinetic energy
     const volVectorField& U = mesh.lookupObject<volVectorField>("U");
@@ -91,18 +110,24 @@ bool Foam::functionObjects::beamEnergyData::writeData()
     const tensorField& CMI = CM.internalField();
     const vectorField& UI = U.internalField();
     const vectorField& OmegaI = Omega.internalField();
+    const labelList& own = mesh.owner();
+
+    // Second moment of area scaling factor-if not specified in beamProperties
+    // then the value is equal to 1.0
+    const scalar kCI = beam.kCI();
 
     // Energy parameters initialised
-    scalar intE(0);
-    scalar kinE_lin(0);
-    scalar kinE_ang(0);
-    scalar kinE(0);
-    scalar tot_E(0);
+    scalarField intE(beam.nBeams(), 0);
+    scalarField kinE_lin(beam.nBeams(), 0);
+    scalarField kinE_ang(beam.nBeams(), 0);
 
     // Calculation of internal energy at internal faces
     forAll(GammaI, faceI)
     {
-        intE += 0.5*L[0]*
+        const label cellI = own[faceI];
+        const label bI = beam.whichBeam(beam.globalCellIndex(cellI));
+
+        intE[bI] += 0.5*L[cellI]*
         (
             (GammaI[faceI] & (CQI[faceI] & GammaI[faceI]))
           + (KI[faceI] & (CMI[faceI] & KI[faceI]))
@@ -113,11 +138,23 @@ bool Foam::functionObjects::beamEnergyData::writeData()
     // using cell-centre velocity fields
     forAll(UI, cellI)
     {
-        kinE_lin += 0.5*rho.value()*L[0]*
+        const label bI = beam.whichBeam(beam.globalCellIndex(cellI));
+
+        const scalar rho = beam.rho(bI).value();
+        const scalar A = beam.A(bI).value();
+
+        const tensor CI
         (
-            A.value()*(UI[cellI] & UI[cellI])
+            kCI*beam.J(bI).value(), 0, 0,
+            0, kCI*beam.Iyy(bI).value(), 0,
+            0, 0, kCI*beam.Izz(bI).value()
         );
-        kinE_ang += 0.5*rho.value()*L[0]*
+
+        kinE_lin[bI] += 0.5*rho*L[cellI]*
+        (
+            A*(UI[cellI] & UI[cellI])
+        );
+        kinE_ang[bI] += 0.5*rho*L[cellI]*
         (
             (OmegaI[cellI] & (CI & OmegaI[cellI]))
         );
@@ -130,10 +167,14 @@ bool Foam::functionObjects::beamEnergyData::writeData()
         const tensorField& pCQ = CQ.boundaryField()[patchI];
         const vectorField& pK = K.boundaryField()[patchI];
         const tensorField& pCM = CM.boundaryField()[patchI];
+        const labelList& faceCells = mesh.boundary()[patchI].faceCells();
 
         forAll(pGamma,faceI)
         {
-            intE += 0.25*L[0]*
+            const label cellI = faceCells[faceI];
+            const label bI = beam.whichBeam(beam.globalCellIndex(cellI));
+
+            intE[bI] += 0.25*L[cellI]*
             (
                 (pGamma[faceI] & (pCQ[faceI] & pGamma[faceI]))
                 + (pK[faceI] & (pCM[faceI] & pK[faceI]))
@@ -141,22 +182,50 @@ bool Foam::functionObjects::beamEnergyData::writeData()
         }
     }
 
-    // Total kinetic energy
-    kinE = kinE_lin + kinE_ang;
-
-    // Total energy
-    tot_E = intE + kinE;
-
     if (Pstream::master())
     {
-        historyFilePtr_()
-        << time_.time().value() << " "
-        << intE << " "
-        << kinE << " "
-        << kinE_lin << " "
-        << kinE_ang << " "
-        << tot_E
-        << endl;
+        scalar totalIntE(0);
+        scalar totalKinE(0);
+        scalar totalKinE_lin(0);
+        scalar totalKinE_ang(0);
+        scalar totalE(0);
+
+        forAll(intE, beamI)
+        {
+            const scalar beamKinE = kinE_lin[beamI] + kinE_ang[beamI];
+            const scalar beamTotE = intE[beamI] + beamKinE;
+
+            totalIntE += intE[beamI];
+            totalKinE += beamKinE;
+            totalKinE_lin += kinE_lin[beamI];
+            totalKinE_ang += kinE_ang[beamI];
+            totalE += beamTotE;
+
+            if (beamHistoryFilePtrs_.set(beamI))
+            {
+                writeEnergyRow
+                (
+                    beamHistoryFilePtrs_[beamI],
+                    time_.time().value(),
+                    intE[beamI],
+                    beamKinE,
+                    kinE_lin[beamI],
+                    kinE_ang[beamI],
+                    beamTotE
+                );
+            }
+        }
+
+        writeEnergyRow
+        (
+            historyFilePtr_(),
+            time_.time().value(),
+            totalIntE,
+            totalKinE,
+            totalKinE_lin,
+            totalKinE_ang,
+            totalE
+        );
     }
 
     return true;
@@ -177,7 +246,8 @@ Foam::functionObjects::beamEnergyData::beamEnergyData
     name_(name),
     time_(runTime),
     regionName_(polyMesh::defaultRegion),
-    historyFilePtr_()
+    historyFilePtr_(),
+    beamHistoryFilePtrs_()
 {
     Info<< "Creating " << this->name() << " function object!" << endl;
 
@@ -188,6 +258,9 @@ Foam::functionObjects::beamEnergyData::beamEnergyData
 
     const fvMesh& mesh =
         time_.lookupObject<fvMesh>(regionName_);
+
+    const beamModel& beam =
+        mesh.objectRegistry::parent().lookupObject<beamModel>("beamProperties");
 
     // Create history file if not already created
     if (!historyFilePtr_.valid())
@@ -227,14 +300,26 @@ Foam::functionObjects::beamEnergyData::beamEnergyData
             // Add headers to output data
             if (historyFilePtr_.valid())
             {
-                historyFilePtr_()
-                << "Time" << " "
-                << "E_{int}" << " "
-                << "E_{kin}" << " "
-                << "E_{kin-lin}" << " "
-                << "E_{kin-ang}" << " "
-                << "E_{tot}"
-                << endl;
+                writeEnergyHeader(historyFilePtr_());
+            }
+
+            beamHistoryFilePtrs_.setSize(beam.nBeams());
+
+            for (label beamI = 0; beamI < beam.nBeams(); ++beamI)
+            {
+                OStringStream beamFileName;
+                beamFileName() << "beamEnergyData_beam" << beamI << ".dat";
+
+                beamHistoryFilePtrs_.set
+                (
+                    beamI,
+                    new OFstream(historyDir/word(beamFileName.str()))
+                );
+
+                if (beamHistoryFilePtrs_.set(beamI))
+                {
+                    writeEnergyHeader(beamHistoryFilePtrs_[beamI]);
+                }
             }
         }
     }

--- a/src/wireBunchingModels/functionObjects/beamEnergyData/beamEnergyData.H
+++ b/src/wireBunchingModels/functionObjects/beamEnergyData/beamEnergyData.H
@@ -73,6 +73,9 @@ class beamEnergyData
         //- Forces/moment file ptr
         autoPtr<OFstream> historyFilePtr_;
 
+        //- Per-beam energy file ptrs
+        PtrList<OFstream> beamHistoryFilePtrs_;
+
     // Private Member Functions
 
         //- Write data


### PR DESCRIPTION
The following changes have been made:

1. Fix self-weight source term to be consistent with the multiple beam dictionary with different rho and area b3393a57279efb3a0cc08f6dcd417ea033699ad2

2. Amend beamEnergyData functionObject to calculate energy of individual beam with consistent geometric parameters - fixed for multiple beams 8f1978281d8c38dc33746e372f07a326385994dd

This PR addresses the issue flagged here: https://github.com/solids4foam/beamFoam/issues/33


FYI @philipcardiff, and @cloner0110.