### PR TITLE
Add tutorial video demonstration links

### DIFF
--- a/tutorials/3dDynamicCantilever/README.md
+++ b/tutorials/3dDynamicCantilever/README.md
@@ -4,6 +4,10 @@ sort: 1
 
 # 3-D Dynamic Cantilever
 
+## Video Demonstration
+
+[![3-D Dynamic Cantilever video demonstration](https://img.youtube.com/vi/Ujd_9cJjilk/maxresdefault.jpg)](https://youtu.be/Ujd_9cJjilk)
+
 ## Tutorial Aims
 
 This tutorial demonstrates how to:

--- a/tutorials/cantilever/README.md
+++ b/tutorials/cantilever/README.md
@@ -1,5 +1,9 @@
 # Case 4: In-Plane Bending of a Cantilever Beam Subjected to Concentrated Moment
 
+## Video Demonstration
+
+[![Cantilever beam video demonstration](https://img.youtube.com/vi/77_MZXnoDrM/maxresdefault.jpg)](https://youtu.be/77_MZXnoDrM)
+
 ## Overview
 This benchmark test investigates the **in-plane pure flexural bending** of a cantilever beam subjected to a concentrated moment at its free end.  
 The problem has been widely studied in the literature [Simo & Vu-Quoc (1986), Ibrahimbegovic (1995)] and serves to validate beam formulations for large in-plane rotations.

--- a/tutorials/cantileverFollowerForce/README.md
+++ b/tutorials/cantileverFollowerForce/README.md
@@ -4,6 +4,10 @@ sort: 2
 
 # In-Plane Cantilever Subjected to an End Follower Load
 
+## Video Demonstration
+
+[![In-plane cantilever follower force video demonstration](https://img.youtube.com/vi/cPaWSjgdrjw/maxresdefault.jpg)](https://youtu.be/cPaWSjgdrjw)
+
 ## Tutorial Aims
 
 This tutorial demonstrates how to:

--- a/tutorials/freeFlexibleBeam/README.md
+++ b/tutorials/freeFlexibleBeam/README.md
@@ -4,6 +4,10 @@ sort: 3
 
 # Free Flexible Beam: Kayak-Rowing Motion
 
+## Video Demonstration
+
+[![Free flexible beam video demonstration](https://img.youtube.com/vi/A-Cg-AX44xA/maxresdefault.jpg)](https://youtu.be/A-Cg-AX44xA)
+
 ## Tutorial Aims
 
 This tutorial demonstrates how to:


### PR DESCRIPTION
Embedding youtube links for tutorial cases of beamFoam repo - then the  README files will be symbolically linked to solids4Foam webpage sister-repository.