### PR TITLE
Documentation: make the markdown lint-clean and check it in CI

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,29 @@
+# Check formatting of markdown files
+#
+# beamFoam READMEs are published on www.solids4foam.com, where they are
+# consumed as a git submodule and linted by that site's own CI. This workflow
+# catches the same problems here, at the point they are introduced.
+#
+# Note: deliberately no .markdownlint.json in this repository. markdownlint-cli2
+# discovers a repository-level config from the linted file's directory upwards,
+# so a config here would be picked up when the website lints its submodules and
+# would silently override the website's own configuration.
+name: Markdown Lint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run MarkdownLint
+        run: npx markdownlint-cli2 "**/*.md"

--- a/tutorials/cantilever/README.md
+++ b/tutorials/cantilever/README.md
@@ -1,48 +1,64 @@
 # Case 4: In-Plane Bending of a Cantilever Beam Subjected to Concentrated Moment
 
 ## Overview
-This benchmark test investigates the **in-plane pure flexural bending** of a cantilever beam subjected to a concentrated moment at its free end.  
-The problem has been widely studied in the literature [Simo & Vu-Quoc (1986), Ibrahimbegovic (1995)] and serves to validate beam formulations for large in-plane rotations.
+
+This benchmark test investigates the **in-plane pure flexural bending** of a
+cantilever beam subjected to a concentrated moment at its free end.
+
+The problem has been widely studied in the literature [Simo & Vu-Quoc (1986),
+Ibrahimbegovic (1995)] and serves to validate beam formulations for large
+in-plane rotations.
 
 ---
 
 ## Geometry and Setup
-- **Beam length:** `L = 10 m`  
-- **Initial configuration:** straight cantilever, clamped at the left end  
-- **Discretisation:** `10 CVs` (tested also with 5, 20, 40 CVs for convergence)  
+
+- **Beam length:** `L = 10 m`
+- **Initial configuration:** straight cantilever, clamped at the left end
+- **Discretisation:** `10 CVs` (tested also with 5, 20, 40 CVs for convergence)
+
 ---
+
 ## Material Properties
-- Axial rigidity: `EA = 1 × 10⁴ N`  
-- Shear rigidity: `GA₂ = GA₃ = 5000 N`  
-- Flexural rigidity: `EI₂ = EI₃ = 100 Nm²`  
-- Torsional rigidity: `GJ = 100 Nm²`  
-- Cross-section radius: `r = 0.2 m`  
-- Young’s modulus: `E = 7.95 × 10⁴ Pa`  
-- Poisson’s ratio: `ν = 0`  
+
+- Axial rigidity: `EA = 1 × 10⁴ N`
+- Shear rigidity: `GA₂ = GA₃ = 5000 N`
+- Flexural rigidity: `EI₂ = EI₃ = 100 Nm²`
+- Torsional rigidity: `GJ = 100 Nm²`
+- Cross-section radius: `r = 0.2 m`
+- Young's modulus: `E = 7.95 × 10⁴ Pa`
+- Poisson's ratio: `ν = 0`
 
 ---
 
 ## Boundary Conditions
-- **Left end:** clamped (fixed displacements and rotations).  
-- **Right end (free end):** subjected to a **concentrated moment** about the z-axis:  
-  - Example: `M_z = 20π Nm` applied in 4 increments.  
-- Analytical solution (Euler formula):  
+
+- **Left end:** clamped (fixed displacements and rotations).
+- **Right end (free end):** subjected to a **concentrated moment** about the
+  z-axis:
+  - Example: `M_z = 20π Nm` applied in 4 increments.
+- Analytical solution (Euler formula):
+
   \[
-  ψ_z = \frac{M_z L}{EI}, \quad w_x = L - \frac{L}{ψ_z/2} \sin(ψ_z/2) \cos(ψ_z/2), \quad w_y = \frac{L}{ψ_z/2} \left( \sin(ψ_z/2) \right)^2
+  ψ_z = \frac{M_z L}{EI}, \quad
+  w_x = L - \frac{L}{ψ_z/2} \sin(ψ_z/2) \cos(ψ_z/2), \quad
+  w_y = \frac{L}{ψ_z/2} \left( \sin(ψ_z/2) \right)^2
   \]
 
 ---
 
 ## Numerical Setup
-- Discretisation: `10 CVs` (refined up to 40 CVs for convergence).  
-- Newton–Raphson solver with average of 6 iterations per increment.  
-- Execution time: `< 0.5 s` for 10 CVs.  
+
+- Discretisation: `10 CVs` (refined up to 40 CVs for convergence).
+- Newton–Raphson solver with average of 6 iterations per increment.
+- Execution time: `< 0.5 s` for 10 CVs.
 
 ---
 
 ## Results
 
 ### Deformation Pattern
+
 - For `M_z = 20π Nm (ψ_z = 2π)`, the beam bends into a full circle.
 
 ### Video Demonstration
@@ -52,8 +68,10 @@ The problem has been widely studied in the literature [Simo & Vu-Quoc (1986), Ib
 ---
 
 ## How to Run
+
 1. Execute:
-```
+
+```bash
 ./Allclean
 ./Allrun
 ```
@@ -63,5 +81,10 @@ Post-process in ParaView (`WarpByVector` using `pointW`).
 ---
 
 ## References
-- Simo, J.C., & Vu-Quoc, L. (1986). *A three-dimensional finite-strain rod model. Part II: Computational aspects.* Computer Methods in Applied Mechanics and Engineering, 58, 79–116.  
-- Ibrahimbegovic, A. (1995). *Computational aspects of vector-like parametrization of three-dimensional finite rotations.* International Journal for Numerical Methods in Engineering, 38(21), 3653–3673.  
+
+- Simo, J.C., & Vu-Quoc, L. (1986). *A three-dimensional finite-strain rod
+  model. Part II: Computational aspects.* Computer Methods in Applied Mechanics
+  and Engineering, 58, 79–116.
+- Ibrahimbegovic, A. (1995). *Computational aspects of vector-like
+  parametrization of three-dimensional finite rotations.* International Journal
+  for Numerical Methods in Engineering, 38(21), 3653–3673.

--- a/tutorials/largeDeflectionCantilever/README.md
+++ b/tutorials/largeDeflectionCantilever/README.md
@@ -1,6 +1,7 @@
 # Large-Deflection of Cantilever (rectangular cross-section) Under Self Weight
 
 ## Overview
+
 This tutorial reproduces the cantilever beam experiment described by
 Belendez, Neipp, and Belendez (2003). The reference problem is a thin,
 rectangular steel cantilever that undergoes geometrically nonlinear bending
@@ -12,6 +13,7 @@ active through `constant/g`, while the free-end displacement boundary condition
 in `0/W` applies zero external end force.
 
 ## Geometry and Material
+
 - Beam length: `L = 0.4 m`
 - Rectangular cross-section width: `b = 0.025 m`
 - Rectangular cross-section height: `h = 0.0004 m`
@@ -20,25 +22,32 @@ in `0/W` applies zero external end force.
 - Shear modulus: `G = 74.73 GPa`
 - Weight of the beam is `0.3032 N`
 - Discretisation: `80 cells`
+
 These values are set in `constant/beamProperties` and `constant/g`.
 
 Two options to add self weight of beam:
-1. Use q field  below - a uniform distributed load representing self-weight
-or 2. Use density and gravity - can be set in constant/
 
-## For a  static load case:
-- Set the self-weight of the beam as uniform distributed load (UDL) of `0.758 N/m`.
-  This UDL can be defined by `0/q` volVectorField
+1. Use the `q` field below - a uniform distributed load representing
+   self-weight.
+2. Use density and gravity - can be set in `constant/`.
 
-## For running a dynamic case, set:
+## For a Static Load Case
+
+- Set the self-weight of the beam as uniform distributed load (UDL) of
+  `0.758 N/m`. This UDL can be defined by the `0/q` volVectorField.
+
+## For Running a Dynamic Case
+
 - Density: `rho = 7730 kg/m^3`
 - Gravity: `(0 0 -9.81) m/s^2` in `constant/g`
 - Set `ddtScheme` and `d2dt2Scheme` in `system/fvSchemes` to Euler or Newmark.
-- NOTE: Euler introduces numerical damping unless time-step size is small (e.g.`0.0001`).
-  Check the beam energy via the function-objects (see below).
-- IMP NOTE: Remove the `q` field else it will take the self-weight into account twice.
+- NOTE: Euler introduces numerical damping unless time-step size is small
+  (e.g. `0.0001`). Check the beam energy via the function-objects (see below).
+- IMP NOTE: Remove the `q` field else it will take the self-weight into account
+  twice.
 
 ## Boundary Conditions
+
 - Left end: clamped displacement and rotation through `fixedValue` entries in
   `0/W` and `0/Theta`.
 - Right end: zero applied moment in `0/Theta`.
@@ -47,6 +56,7 @@ or 2. Use density and gravity - can be set in constant/
   only due to self weight.
 
 To apply a different end force, modify both:
+
 - `constant/timeVsForce`, which defines the time history and direction
   of the force.
 - The right-patch boundary condition in `0/W`, enabling or updating the
@@ -56,6 +66,7 @@ If these are not changed, the tutorial should be interpreted as the self-weight
 bending case.
 
 ## Running the Case
+
 From this directory, run:
 
 ```sh
@@ -67,6 +78,7 @@ From this directory, run:
 `beamFoam`.
 
 ## Function Objects
+
 This case enables two function objects in `system/controlDict`:
 
 - `beamDisplacements1`
@@ -87,6 +99,7 @@ The provided `allPlots.gnuplot` script reads these two files directly and
 generates `energyPlot.pdf` and `displacementPlot.pdf`.
 
 ## Post-Processing
+
 Open the generated case in ParaView and visualise the deformed beam with
 `pointW` using `Warp By Vector`. The free-end vertical displacement can be
 compared against the reference paper values for the self-weight case or for
@@ -99,6 +112,7 @@ gnuplot allPlots.gnuplot
 ```
 
 ## Reference paper
+
 Belendez, T., Neipp, C., and Belendez, A. (2003). *Numerical and Experimental
 Analysis of a Cantilever Beam: a Laboratory Project to Introduce Geometric
 Nonlinearity in Mechanics of Materials*. International Journal of Engineering
@@ -106,18 +120,21 @@ Education, 19(6), 885-892.
 
 ## Validation Against Reference Paper
 
-The numerical results can be directly compared with experimental data from  
+The numerical results can be directly compared with experimental data from
 Belendez et al. (2003). The beam is discretised with 80 beam cells.
 
-### Table 1: Free-end vertical displacement \( \delta_y \) vs applied load \( F \)
+### Table 1: Free-end vertical displacement vs applied load
 
-| F (N) | δy (m) Experimental | δy (m) Numerical (E = 194.3 GPa) | Relative Error |
-|------:|--------------------:|----------------------------------:|---------------:|
-| 0.000 | 0.089  | 0.0898 | 0.89% |
-| 0.098 | 0.149  | 0.1516 | 1.71% |
-| 0.196 | 0.195  | 0.1960 | 0.25% |
-| 0.294 | 0.227  | 0.2270 | 0.51% |
-| 0.392 | 0.251  | 0.2495 | 0.60% |
-| 0.490 | 0.268  | 0.2659 | 0.78% |
-| 0.588 | 0.281  | 0.2784 | 0.90% |
+Displacement \( \delta_y \) against applied load \( F \):
 
+| F (N) | δy (m) Experimental | δy (m) Numerical | Relative Error |
+| ---: | ---: | ---: | ---: |
+| 0.000 | 0.089 | 0.0898 | 0.89% |
+| 0.098 | 0.149 | 0.1516 | 1.71% |
+| 0.196 | 0.195 | 0.1960 | 0.25% |
+| 0.294 | 0.227 | 0.2270 | 0.51% |
+| 0.392 | 0.251 | 0.2495 | 0.60% |
+| 0.490 | 0.268 | 0.2659 | 0.78% |
+| 0.588 | 0.281 | 0.2784 | 0.90% |
+
+The numerical column is computed with `E = 194.3 GPa`.

--- a/tutorials/mooringLineInitialisation/README.md
+++ b/tutorials/mooringLineInitialisation/README.md
@@ -1,33 +1,49 @@
 # Mooring Line Initialisation — Catenary Settling with Seabed Contact
 
 ## Overview
-This tutorial demonstrates the **static initialisation of a catenary mooring line**: a finite-volume beam is placed on the straight chord between the anchor and the fairlead, and then dynamically settles under gravity, buoyancy, seabed contact and hydrodynamic damping into its static catenary shape.
 
-The resulting equilibrium configuration (hanging catenary + grounded segment resting on the seabed) is the standard starting point for moored floating body simulations with the `moorFV` coupling library, where the initialised beam is used as a mooring-line restraint on a 6-DoF rigid body [Taran et al. (2025)].
+This tutorial demonstrates the **static initialisation of a catenary mooring
+line**: a finite-volume beam is placed on the straight chord between the anchor
+and the fairlead, and then dynamically settles under gravity, buoyancy, seabed
+contact and hydrodynamic damping into its static catenary shape.
+
+The resulting equilibrium configuration (hanging catenary + grounded segment
+resting on the seabed) is the standard starting point for moored floating body
+simulations with the `moorFV` coupling library, where the initialised beam is
+used as a mooring-line restraint on a 6-DoF rigid body [Taran et al. (2025)].
 
 The case exercises two runtime-selectable **beam momentum contributions**:
+
 - `groundContact` — penalty spring/damper seabed contact,
 - `morisonDrag` — Morison drag through still water (pure damping here).
 
 ---
 
 ## Initialisation Procedure
+
 The `Allrun` script performs the three stages sketched below:
 
-1. **`createBeamMesh`** — creates a straight beam mesh of length `L = 1.45 m` along the x-axis (60 control volumes, from `constant/beamProperties`).
-2. **`setInitialPositionBeam`** — rigidly rotates the beam from the x-axis onto the anchor–fairlead chord direction and translates its first end onto the anchor point on the seabed.
-3. **`beamFoam`** — transient settling run from `t = 0` to `t = 2 s`: the line sags under its effective (submerged) weight, the touchdown section is caught by the seabed contact model, Morison drag damps the transients, and the fairlead end is simultaneously ramped from the chord end to its target fairlead position by a prescribed displacement series.
+1. **`createBeamMesh`** — creates a straight beam mesh of length `L = 1.45 m`
+   along the x-axis (60 control volumes, from `constant/beamProperties`).
+2. **`setInitialPositionBeam`** — rigidly rotates the beam from the x-axis onto
+   the anchor–fairlead chord direction and translates its first end onto the
+   anchor point on the seabed.
+3. **`beamFoam`** — transient settling run from `t = 0` to `t = 2 s`: the line
+   sags under its effective (submerged) weight, the touchdown section is caught
+   by the seabed contact model, Morison drag damps the transients, and the
+   fairlead end is simultaneously ramped from the chord end to its target
+   fairlead position by a prescribed displacement series.
 
-```
+```text
  z = 0   ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~   free surface
                                                     o  <-- (2) chord end
-                                                   *o  <-- (3) fairlead end ramped
-                                               _.-* |          to target over 0..2 s
+                                                   *o  <-- (3) fairlead ramped
+                                               _.-* |          to target, 0..2 s
                         (2) straight        _.-*    |
                             chord        _.-*      /
                             after     _.-*        |
               setInitialPositionBeam *         (3) line settles into a catenary:
-                                _.-*            |   gravity + buoyancy, damped by
+                                _.-*            |   gravity+buoyancy, damped by
                              _.-*              /        morisonDrag contribution
                           _.-*               _/
                        _.-*               __/
@@ -44,15 +60,20 @@ The `Allrun` script performs the three stages sketched below:
 
 - **Anchor** (left patch): `(-1.385, -0.423, -0.5)` — clamped on the seabed.
 - **Chord direction:** unit vector `(0.904, 0.276, 0.326)`.
-- **Fairlead ramp** (right patch): total displacement `(-0.024, -0.0773, -0.051) m` relative to the chord end, applied linearly over `t ∈ [0, 2 s]` via `constant/timeVsDisplacement`.
+- **Fairlead ramp** (right patch): total displacement
+  `(-0.024, -0.0773, -0.051) m` relative to the chord end, applied linearly
+  over `t ∈ [0, 2 s]` via `constant/timeVsDisplacement`.
 
 ---
 
 ## Geometry and Line Properties
-The line represents a 1:80 model-scale studless mooring chain, modelled as an equivalent cylinder [Taran et al. (2025)]:
+
+The line represents a 1:80 model-scale studless mooring chain, modelled as an
+equivalent cylinder [Taran et al. (2025)]:
 
 - **Unstretched length:** `L = 1.45 m`
-- **Cross-section:** circular, radius `R = 1.828 mm` (equivalent diameter `d = 3.656 mm`)
+- **Cross-section:** circular, radius `R = 1.828 mm` (equivalent diameter
+  `d = 3.656 mm`)
 - **Discretisation:** `60` beam CVs
 - **Young's modulus:** `E = 1.826 MPa`
 - **Shear modulus:** `G = 0.913 MPa`
@@ -64,29 +85,45 @@ The line represents a 1:80 model-scale studless mooring chain, modelled as an eq
 ---
 
 ## Boundary Conditions
-- **`left` patch (anchor):** displacement `W` fixed to zero (`fixedValue`), i.e. the anchor is pinned to the seabed.
-- **`right` patch (fairlead):** `fixedDisplacement` with a `displacementSeries` interpolated from `constant/timeVsDisplacement`.
-- **Rotation `Theta`:** `momentBeamRotationNR` on both ends with a zero moment series (`constant/timeVsMoment`), i.e. moment-free ends.
+
+- **`left` patch (anchor):** displacement `W` fixed to zero (`fixedValue`),
+  i.e. the anchor is pinned to the seabed.
+- **`right` patch (fairlead):** `fixedDisplacement` with a `displacementSeries`
+  interpolated from `constant/timeVsDisplacement`.
+- **Rotation `Theta`:** `momentBeamRotationNR` on both ends with a zero moment
+  series (`constant/timeVsMoment`), i.e. moment-free ends.
 
 ---
 
 ## Seabed Contact and Damping
-Both models are configured in `constant/beamMomentumContributionProperties` (not in `beamProperties`):
 
-- **`groundContact`:** beam cells penetrating below `groundZ = -0.5 m` receive a normal penalty force with spring stiffness `kNormal = 1e3` and damping `cNormal = 1.0` (tangential stiffness and friction disabled here). The penalty is deliberately soft, giving a stable penetration of a few millimetres.
-- **`morisonDrag`:** drag coefficients `Cdn = 1.6` / `Cdt = 0.05` acting on the beam's own velocity through still water. With no dissipation the line would bounce indefinitely instead of settling; the Morison drag provides the hydrodynamic damping that brings it to rest as a catenary by `t = 2 s`.
+Both models are configured in
+`constant/beamMomentumContributionProperties` (not in `beamProperties`):
+
+- **`groundContact`:** beam cells penetrating below `groundZ = -0.5 m` receive
+  a normal penalty force with spring stiffness `kNormal = 1e3` and damping
+  `cNormal = 1.0` (tangential stiffness and friction disabled here). The
+  penalty is deliberately soft, giving a stable penetration of a few
+  millimetres.
+- **`morisonDrag`:** drag coefficients `Cdn = 1.6` / `Cdt = 0.05` acting on the
+  beam's own velocity through still water. With no dissipation the line would
+  bounce indefinitely instead of settling; the Morison drag provides the
+  hydrodynamic damping that brings it to rest as a catenary by `t = 2 s`.
 
 ---
 
 ## Numerical Setup
-- **Time integration:** Euler (first-order, implicit); `Δt = 0.002 s`, `t_end = 2 s`
+
+- **Time integration:** Euler (first-order, implicit); `Δt = 0.002 s`,
+  `t_end = 2 s`
 - **Linear solver:** Eigen (direct)
 - **Newton–Raphson tolerances:** `absoluteTol = 1e-7`, `residualTol = 1e-5`
 
 ---
 
 ## Running the Case
-```
+
+```sh
 ./Allclean
 ./Allrun
 ```
@@ -94,18 +131,35 @@ Both models are configured in `constant/beamMomentumContributionProperties` (not
 ---
 
 ## Post-processing
+
 - Open the case in **ParaView** (`case.foam`).
-- Use the **WarpByVector** filter with the `pointW` field to visualise the deformed line (the mesh itself stays straight along the chord; `pointW` carries the displacement).
-- The catenary shape at `t = 2 s` can be compared with the quasi-static lumped-mass solution (e.g. MoorDyn) and the experimental static tensions reported in Taran et al. (2025).
+- Use the **WarpByVector** filter with the `pointW` field to visualise the
+  deformed line (the mesh itself stays straight along the chord; `pointW`
+  carries the displacement).
+- The catenary shape at `t = 2 s` can be compared with the quasi-static
+  lumped-mass solution (e.g. MoorDyn) and the experimental static tensions
+  reported in Taran et al. (2025).
 
 ---
 
 ## Expected Results
-- The line settles into a **static catenary with a grounded segment**: about `28` of the `60` CVs are in seabed contact at `t = 2 s`, with a stable penetration of a few millimetres (soft penalty).
-- Newton–Raphson converges in **~4 iterations per time step**; total run time is a few seconds on a single core.
-- The settled state (`2/` time directory) can be copied into a `moorFV` CFD case as the mooring-line initial condition. When doing so, change the `right` patch of `W` from `fixedDisplacement` to a `fixedValue` condition (the fairlead is then driven by the coupled 6-DoF body motion instead of the prescribed series).
+
+- The line settles into a **static catenary with a grounded segment**: about
+  `28` of the `60` CVs are in seabed contact at `t = 2 s`, with a stable
+  penetration of a few millimetres (soft penalty).
+- Newton–Raphson converges in **~4 iterations per time step**; total run time
+  is a few seconds on a single core.
+- The settled state (`2/` time directory) can be copied into a `moorFV` CFD
+  case as the mooring-line initial condition. When doing so, change the `right`
+  patch of `W` from `fixedDisplacement` to a `fixedValue` condition (the
+  fairlead is then driven by the coupled 6-DoF body motion instead of the
+  prescribed series).
 
 ---
 
 ## References
-- Taran, A., Bali, S., Tuković, Ž., Pakrashi, V., & Cardiff, P. (2025). *A finite volume Simo-Reissner beam method for moored floating body dynamics.* Applied Ocean Research, 165, 104845. https://doi.org/10.1016/j.apor.2025.104845
+
+- Taran, A., Bali, S., Tuković, Ž., Pakrashi, V., & Cardiff, P. (2025).
+  *A finite volume Simo-Reissner beam method for moored floating body
+  dynamics.* Applied Ocean Research, 165, 104845.
+  [10.1016/j.apor.2025.104845](https://doi.org/10.1016/j.apor.2025.104845)


### PR DESCRIPTION
The beamFoam tutorial READMEs are published on <https://www.solids4foam.com>, which consumes this repository as a git submodule and lints it with `markdownlint-cli2`. Three READMEs did not pass:

| File | Errors |
| --- | --- |
| `tutorials/cantilever/README.md` | 27 |
| `tutorials/largeDeflectionCantilever/README.md` | 36 |
| `tutorials/mooringLineInitialisation/README.md` | 42 |

Mostly missing blank lines around headings and lists, unwrapped lines, non-compact table pipes, fenced blocks with no language, and headings ending in a colon.

**Formatting only** — no technical content changed. The MathJax equation block in the cantilever README is preserved as LaTeX (the site loads MathJax site-wide). The single wording change is in `largeDeflectionCantilever`, where the Table 1 heading exceeded the line limit, so the load symbols moved into a sentence above the table.

### The workflow

`.github/workflows/markdownlint.yml` runs `npx markdownlint-cli2 "**/*.md"` on pushes and PRs to `main`, so this is caught here rather than downstream on the website.

There is **deliberately no `.markdownlint.json`** in this repository. `markdownlint-cli2` discovers a repository-level config by walking up from the linted file's directory, so a config here would be picked up when the website lints `imported/**` and would silently override the website's own configuration.

Verified locally: 9 files linted, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)